### PR TITLE
fix: Add double quotes to syntax angle property

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -564,7 +564,7 @@ module.exports = plugin(
         animationPlayState: 'paused',
       },
       '@property --border-angle': {
-        syntax: '<angle>',
+        syntax: '"<angle>"',
         inherits: true,
         'initial-value': '0turn',
       },


### PR DESCRIPTION
## Bug
`@property` syntax values without quotes cause a parsing error with Turbopack (Next.js 16.2.4).

### Usage
```css
/* /app/globals.css */

@plugin 'lightswind/plugin';
```

### Logs
```bash
## Error Type
Build Error

## Error Message
Parsing CSS source code failed

## Build Output
./app/globals.css:869:12
Parsing CSS source code failed
  867 |   }
  868 |   @property --border-angle {
> 869 |     syntax: <angle>;
      |            ^
  870 |     inherits: true;
  871 |     initial-value: 0turn;
  872 |   }

Unexpected token Delim('<')

Generated code of PostCSS transform of file content of app/globals.css:
./app/globals.css:869:12
  867 |   }
  868 |   @property --border-angle {
> 869 |     syntax: <angle>;
      |            ^
  870 |     inherits: true;
  871 |     initial-value: 0turn;
  872 |   }

Import trace:
  Client Component Browser:
    ./app/globals.css [Client Component Browser]
    ./app/layout.tsx [Server Component]

Next.js version: 16.2.4 (Turbopack)

```

## Root cause
CSS Houdini spec requires the `syntax` descriptor value to be a quoted string. Line 547 of `plugin.js` generates it without quotes, while line 141 (same file) already does it correctly.

## Fix
Wrap the `<angle>` value in quotes to match the spec and fix Turbopack compatibility.

## References
- CSS Properties and Values API spec: https://drafts.css-houdini.org/css-properties-values-api/#the-syntax-descriptor